### PR TITLE
add dependencies from requirements.txt to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     author_email='brantley@forge.works',
     packages=['delta'],
     license="MIT License",
-    install_requires=['diff-match-patch'],
+    install_requires=['cssutils', 'diff-match-patch', 'lxml'],
     setup_requires=['pytest-runner'],
     tests_require=['pytest', 'mock'],   
 )


### PR DESCRIPTION
Adding the dependencies from requirements.txt will allow adding this repository as a package in another project's requirement.txt to pull the required dependencies correctly.
